### PR TITLE
Terminal: Refactor :ls (ListCommand) for readability and testability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,226 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+azstore is a .NET 9 terminal application that provides a command-line REPL interface for interacting with Azure Blob Storage. The application allows cloud engineers, developers, and operations personnel to authenticate, browse containers and blobs, and download files using a keyboard-driven workflow with VIM-like keybindings.
+
+## Key Requirements
+
+- Terminal-based REPL for Azure Blob Storage with VIM-like navigation (j/k/h/l keys, gg/G for jump navigation)
+- Multi-character key sequence support with configurable timeout for true VIM-like experience
+- Session-based workflow with Azure CLI authentication
+- File download with mirrored directory structure and conflict resolution
+- Cross-platform compatibility with TOML configuration support
+- Extensible command system with colon-prefixed built-ins (:ls, :help, :exit, :q)
+
+## Current Architecture
+
+The project uses a layered architecture with the following components:
+
+### Core Projects
+- **AzStore.CLI**: Main executable with hosted services architecture, Serilog integration
+- **AzStore.Configuration**: Settings management with TOML configuration support
+- **AzStore.Core**: Business logic and Azure Blob Storage integration
+- **AzStore.Terminal**: REPL engine with theme support and command processing
+
+### Test Projects
+- **AzStore.CLI.Tests**: Service registration and dependency injection tests
+- **AzStore.Configuration.Tests**: Settings validation and configuration tests
+- **AzStore.Core.Tests**: Business logic unit tests
+- **AzStore.Terminal.Tests**: REPL functionality and theming tests
+
+### Technical Stack
+- **Target Framework**: .NET 9
+- **Architecture**: Microsoft.Extensions.Hosting with hosted services
+- **Command System**: Extensible command pattern with dependency injection
+- **Logging**: Serilog with console and file sinks, structured logging
+- **Configuration**: Microsoft.Extensions.Configuration with TOML support
+- **Azure Integration**: Azure.Storage.Blobs SDK
+- **Testing**: xUnit with standard assertions, NSubstitute for mocking
+- **Development**: VS Code integration with comprehensive debugging support
+
+## Configuration
+
+Hierarchical configuration: appsettings.json → TOML config (`%APPDATA%\azstore\azstore.toml` or `~/.config/azstore/azstore.toml`) → `AZSTORE_*` environment variables. Covers logging, themes, key bindings, file conflicts, and session management.
+
+## Command System Architecture
+
+The application uses an extensible command pattern with dependency injection for maximum testability and maintainability.
+
+### Core Components
+- **ICommand Interface**: Defines command contract with `Name`, `Aliases`, `Description`, and `ExecuteAsync`
+- **CommandRegistry**: Service that discovers and provides command lookup functionality
+- **CommandResult**: Standardized result type with success status, messages, and exit flags
+- **Built-in Commands**: ExitCommand, HelpCommand, ListCommand
+
+### Adding New Commands
+1. Create a class implementing `ICommand` interface
+2. Add constructor dependencies as needed (logger, services, etc.)
+3. Register as `ICommand` in ServiceCollectionExtensions
+4. Command is automatically discovered and available in REPL
+
+### Example Command Implementation
+```csharp
+public class MyCommand : ICommand 
+{
+    public string Name => "mycommand";
+    public string[] Aliases => ["mc"];  // Uses C# 12 collection expressions
+    public string Description => "Does something useful";
+    
+    public MyCommand(ILogger<MyCommand> logger) { /* ... */ }
+    
+    public Task<CommandResult> ExecuteAsync(string[] args, CancellationToken ct)
+    {
+        // Implementation here
+        return Task.FromResult(CommandResult.Ok("Success!"));
+    }
+}
+```
+
+## Development Practices
+
+### Testing Strategy
+- **Test Architecture**: Fixture and Assertions pattern for clean test organization
+- **Mocking**: NSubstitute for dependency substitution
+- **Assertions**: Standard xUnit assertions only (no FluentAssertions)
+- **Coverage**: Comprehensive unit tests for all major components
+- **Test Categories**: Unit tests use `[Trait("Category", "Unit")]`, Integration tests use `[Trait("Category", "Integration")]`
+- **CI Filtering**: Use `--filter "Category!=Integration"` to exclude integration tests in CI builds where Azure CLI may not be available
+
+### Code Standards
+- **Dependency Injection**: Constructor injection with ILogger<T> pattern
+- **Async/Await**: Proper cancellation token propagation
+- **Error Handling**: Comprehensive exception handling with graceful degradation
+- **Cross-Platform**: Platform-specific path handling for Windows/macOS/Linux
+- **Modern C# Features**: Use C# 12 collection expressions `[]` instead of `new[]` for arrays and simple collections
+- **Threading**: Use `System.Threading.Lock` instead of `object` for synchronization in .NET 9 for 25% performance improvement
+- **Parameter Validation**: Rely on nullable reference types and compiler safety instead of manual guards - let Azure SDK handle parameter validation with meaningful error messages
+- **Comments**: Only include inline comments when they explain non-obvious logic; remove comments that merely restate what code obviously does
+- **Testing**: Use standard xUnit assertions (not FluentAssertions), avoid collection expression ambiguity in `Assert.Equal()`
+- **File Organization**: **MANDATORY** - Put each class, record, struct, enum, and interface in its own code file for better maintainability and discoverability. **NEVER** place multiple types in the same file. This is a strict requirement and must be enforced during code reviews
+- **Expression Bodies**: Use expression-bodied methods when simple and readable. For single-line expressions, use one line: `public int GetValue() => 42;`. For multi-line expressions, put the arrow at the end of the method signature line and indent the body on the next line: `public Result ComplexMethod() => expression;`
+
+### VS Code Integration
+Complete development environment setup:
+- **Debug Configurations**: Multiple launch profiles (Development, Production, Verbose)
+- **Build Tasks**: Automated build, test, watch, and publish tasks
+- **Extensions**: Recommended extensions for .NET development
+- **Settings**: Optimized workspace configuration
+
+## Build and Runtime
+
+### Commands
+- `dotnet build src/Azstore.sln` - Build solution
+- `dotnet test src/Azstore.sln` - Run all tests
+- `dotnet run --project src/AzStore.CLI` - Start application
+
+### Output Structure
+- **Executable**: `src/AzStore.CLI/bin/Debug/net9.0/azstore.dll`
+- **Cross-Platform**: Supports Windows, macOS, and Linux
+- **Self-Contained**: All dependencies included in output
+
+## Current Implementation Status
+
+### ✅ Completed Features
+- Hosted services architecture with graceful shutdown
+- Comprehensive logging infrastructure with Serilog
+- TOML-based configuration system
+- **Extensible command system with dependency injection**
+- **Command registry pattern for easy command addition**
+- **REPL engine with pluggable command architecture**
+- Built-in commands (:help, :exit/:q, :list/:ls)
+- Theme support with configurable colors
+- Cross-platform path handling
+- Dependency injection container setup
+- **Comprehensive test coverage (104+ tests across all layers)**
+- **Modern C# syntax**: Collection expressions used throughout for cleaner array/collection initialization
+
+### ✅ Foundation Phase Complete
+- **Core domain models**: Session, Container, Blob, NavigationState, StorageItem with validation and serialization
+- **Service interfaces**: IStorageService, ISessionManager, IAuthenticationService, IConfigurationService, IReplEngine, ICommandProcessor
+- **Model tests**: 53 comprehensive unit tests with xUnit assertions for all models
+
+### ✅ Authentication Phase Complete (Issue #6)
+- **Azure CLI authentication service**: Full implementation using DefaultAzureCredential with AzureCliCredential only
+- **Cross-platform support**: Works on Windows, macOS, and Linux
+- **Comprehensive error handling**: Graceful handling of Azure CLI not installed/authenticated scenarios
+- **Token management**: Automatic token refresh and caching with expiration handling
+- **Subscription management**: Enumerate available subscriptions and storage accounts
+- **Test coverage**: 28 unit tests + 8 integration tests with category traits for CI filtering
+- **Dependencies**: Azure.Identity (1.12.1), Azure.ResourceManager (1.13.0), Azure.ResourceManager.Storage (1.3.0)
+
+### ✅ Paging Implementation Complete
+- **Azure Storage Paging**: Replaced `IAsyncEnumerable` methods with explicit paging using `PagedResult<T>` and `PageRequest`
+- **Azure SDK Integration**: Uses `AsPages()` method for efficient server-side pagination with continuation tokens
+- **Breaking Change**: Removed streaming enumeration in favor of explicit page-by-page access for better REPL control
+- **Memory Efficiency**: Only loads one page at a time instead of streaming all results
+- **Test Coverage**: Updated all 156+ tests to use new paged API, added comprehensive paging tests
+- **REPL-Optimized**: Perfect for interactive scenarios where users navigate through containers/blobs page by page
+
+### ✅ Multi-Character Key Bindings Complete (Issue #40)
+- **KeySequenceBuffer**: Implements buffering system for multi-character key sequences like 'gg' and 'dd'
+- **Timeout Management**: Configurable timeout (default 1000ms) to distinguish intentional sequences from accidental key presses
+- **Prefix Matching**: Handles cases where one binding is a prefix of another (e.g., 'g' and 'gg')
+- **VIM-like Navigation**: True VIM-style bindings with 'gg' (jump to top), 'G' (jump to bottom), 'dd' (download)
+- **Backward Compatibility**: Existing single-character bindings continue to work unchanged
+- **Configuration Support**: Multi-character sequences and timeout configurable via TOML settings
+- **Comprehensive Testing**: 15+ unit tests covering timeout behavior, sequence completion, and prefix conflicts
+
+### 🚧 In Development
+- Session persistence
+- Interactive blob browser with paging navigation
+
+### 📋 Next Phase
+- Interactive blob browser with VIM navigation
+- File conflict resolution
+- Progress indication for downloads
+
+## Development Notes
+
+- Follows Microsoft .NET hosted services patterns with structured logging and hot-reload configuration
+- Extensible command system: implement `ICommand`, register in DI, automatic discovery via `CommandRegistry`
+- Interface-driven architecture with comprehensive DI container setup
+- **Test coverage**: 156+ tests including comprehensive model validation, edge cases, and paging functionality
+
+## Lessons Learned
+
+### Azure SDK Pagination Best Practices
+- **Use AsPages() for Explicit Control**: `GetBlobsAsync().AsPages(continuationToken, pageSize)` provides better control than `IAsyncEnumerable` for interactive scenarios
+- **Single Page Processing**: When implementing pagination, process only the first page and return immediately - avoid `await foreach` loops that process all pages
+- **Continuation Token Management**: Azure SDK handles opaque continuation tokens; store and pass them between requests without modification
+- **Page Size Limits**: Azure Storage supports up to 5000 items per page; default to smaller sizes (100) for better UX in terminal applications
+
+### REPL Architecture Considerations
+- **Explicit Paging vs Streaming**: For interactive applications, explicit paging (`PagedResult<T>`) is superior to streaming (`IAsyncEnumerable<T>`)
+- **Memory Management**: Paging prevents memory issues when dealing with storage accounts containing thousands of containers/blobs
+- **User Experience**: Page-by-page navigation aligns better with VIM-like keybindings and terminal constraints
+
+### Breaking Changes Management
+- **Interface Evolution**: When replacing method signatures, update all dependent code simultaneously to maintain compilation
+- **Test Migration**: Convert streaming tests to paged tests by replacing `await foreach` with direct method calls
+- **Documentation Updates**: Keep CLAUDE.md current with architectural decisions and implementation status
+
+### Command and Parsing Patterns
+- **Command Args Parsing**: Implement argument parsing as a static factory on the options record (e.g., `ListCommandOptions.FromArgs`). Keeps commands focused on orchestration, improves discoverability, and makes parsing easy to unit test.
+- **Case-Insensitive Flags**: Check flags with `StringComparison.OrdinalIgnoreCase`. For `--key=value` parsing, compute the `=` index and slice from there rather than fixed offsets to avoid off-by-one bugs.
+  - Example: `if (arg.StartsWith("--sort=", StringComparison.OrdinalIgnoreCase)) { var eq = arg.IndexOf('='); sortKey = arg[(eq + 1)..].Trim(); }`
+- **Cancellation & I/O**: Honor `CancellationToken` in REPL/file operations. Throw early and within long-running loops.
+  - Example: `cancellationToken.ThrowIfCancellationRequested();` and inside enumeration loops.
+- **Enumeration Materialization**: Avoid double-enumerating lazy sequences (e.g., `Any()` then `Where()`). Either materialize once before branching or keep the pipeline lazy until just before sorting/formatting, then materialize.
+- **Utility Reuse**: Centralize cross-cutting helpers (e.g., glob-to-regex) under `AzStore.Terminal.Utilities` with compiled, case-insensitive regex. Promotes reuse and simplifies maintenance.
+- **Decompose Instead of Comments**: Replace “section comments” with small, well-named private helpers for readability and alignment with the “minimal comments, self-documenting code” standard.
+- **One Type Per File**: Place new records/types like `ListCommandOptions` in their own files. This is mandatory and should be enforced in reviews.
+- **Parsing Tests**: Add dedicated unit tests for options factories covering defaults, `--flag value` and `--flag=value` variants, ordering of positional args, glob-only patterns, and synonyms (e.g., `--desc`, `--reverse`, `-r`). Tag with `[Trait("Category", "Unit")]` for CI.
+- **VSTest in CI**: Some CI/sandbox environments restrict IPC/sockets. Prefer:
+  - `dotnet test src/Azstore.sln --filter "Category!=Integration" -v minimal -nr:false -m:1` to disable node reuse and reduce concurrency issues.
+
+## Recent Implementation (GitHub Issue #4)
+
+### Foundation Phase Complete
+- **Domain Models**: Session, StorageItem, Container, Blob, NavigationState as C# 12 records with validation/serialization
+- **Service Interfaces**: IStorageService, ISessionManager, IAuthenticationService, IConfigurationService, IReplEngine, ICommandProcessor with full XML docs
+- **Architecture**: Interface extraction, improved DI patterns, command registry with lazy loading
+- **Testing**: Migrated from FluentAssertions to standard xUnit assertions, 104+ tests with comprehensive edge case coverage
+- **Quality**: Modern C# 12 syntax, proper async/await patterns, cross-platform compatibility

--- a/src/AzStore.Core/Models/Navigation/NavigationState.cs
+++ b/src/AzStore.Core/Models/Navigation/NavigationState.cs
@@ -105,7 +105,9 @@ public record NavigationState(
         {
             var lastSlash = BlobPrefix.LastIndexOf('/');
             var newPrefix = lastSlash > 0 ? BlobPrefix[..lastSlash] : null;
-            return CreateInContainer(SessionName, StorageAccountName, ContainerName!, newPrefix);
+            return ContainerName is not null
+                ? CreateInContainer(SessionName, StorageAccountName, ContainerName, newPrefix)
+                : this;
         }
 
         if (ContainerName != null)

--- a/src/AzStore.Core/Services/Abstractions/IConfigurationService.cs
+++ b/src/AzStore.Core/Services/Abstractions/IConfigurationService.cs
@@ -18,9 +18,17 @@ public interface IConfigurationService
     /// </summary>
     /// <typeparam name="T">The type of the configuration value.</typeparam>
     /// <param name="key">The configuration key to retrieve.</param>
+    /// <returns>The configuration value, or null if not found.</returns>
+    T? GetValue<T>(string key);
+
+    /// <summary>
+    /// Gets a specific configuration value by key, or the provided default when missing.
+    /// </summary>
+    /// <typeparam name="T">The type of the configuration value.</typeparam>
+    /// <param name="key">The configuration key to retrieve.</param>
     /// <param name="defaultValue">The default value to return if the key is not found.</param>
     /// <returns>The configuration value, or the default value if not found.</returns>
-    T GetValue<T>(string key, T defaultValue = default!);
+    T GetValueOrDefault<T>(string key, T defaultValue);
 
     /// <summary>
     /// Gets a specific configuration section.

--- a/src/AzStore.Core/Services/Implementations/AuthenticationService.cs
+++ b/src/AzStore.Core/Services/Implementations/AuthenticationService.cs
@@ -45,10 +45,11 @@ public class AuthenticationService : IAuthenticationService
             var subscription = await armClient.GetDefaultSubscriptionAsync(cancellationToken);
             await subscription.GetAsync(cancellationToken);
 
+            var tenantIdText = subscription.Data.TenantId?.ToString();
             var result = AuthenticationResult.Successful(
                 accessToken: "*** (hidden for security)",
                 subscriptionId: subscription.Id.SubscriptionId != null ? Guid.Parse(subscription.Id.SubscriptionId) : null,
-                tenantId: subscription.Data.TenantId?.ToString() != null ? Guid.Parse(subscription.Data.TenantId.ToString()!) : null,
+                tenantId: tenantIdText != null ? Guid.Parse(tenantIdText) : null,
                 accountName: subscription.Data.DisplayName,
                 expiresOn: DateTime.UtcNow.AddHours(1)
             );
@@ -104,10 +105,11 @@ public class AuthenticationService : IAuthenticationService
             var subscription = armClient.GetSubscriptionResource(resourceIdentifier);
             await subscription.GetAsync(cancellationToken);
 
+            var tenantIdText = subscription.Data.TenantId?.ToString();
             var result = AuthenticationResult.Successful(
                 accessToken: "*** (hidden for security)",
                 subscriptionId: subscriptionId,
-                tenantId: subscription.Data.TenantId?.ToString() != null ? Guid.Parse(subscription.Data.TenantId.ToString()!) : null,
+                tenantId: tenantIdText != null ? Guid.Parse(tenantIdText) : null,
                 accountName: subscription.Data.DisplayName,
                 expiresOn: DateTime.UtcNow.AddHours(1)
             );
@@ -223,7 +225,8 @@ public class AuthenticationService : IAuthenticationService
             await foreach (var subscription in armClient.GetSubscriptions().GetAllAsync(cancellationToken))
             {
                 var subscriptionId = subscription.Id.SubscriptionId != null ? Guid.Parse(subscription.Id.SubscriptionId) : Guid.Empty;
-                var tenantId = subscription.Data.TenantId?.ToString() != null ? Guid.Parse(subscription.Data.TenantId.ToString()!) : Guid.Empty;
+                var tenantIdText = subscription.Data.TenantId?.ToString();
+                var tenantId = tenantIdText != null ? Guid.Parse(tenantIdText) : Guid.Empty;
 
                 if (subscriptionId != Guid.Empty)
                 {

--- a/src/AzStore.Terminal.Tests/Commands/ListCommandOptionsTests.cs
+++ b/src/AzStore.Terminal.Tests/Commands/ListCommandOptionsTests.cs
@@ -1,0 +1,80 @@
+using AzStore.Terminal.Commands;
+using Xunit;
+
+namespace AzStore.Terminal.Tests.Commands;
+
+public class ListCommandOptionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FromArgs_NoArgs_Defaults()
+    {
+        var opts = ListCommandOptions.FromArgs([]);
+        Assert.Null(opts.Container);
+        Assert.Null(opts.Pattern);
+        Assert.Equal("name", opts.SortKey);
+        Assert.False(opts.Descending);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FromArgs_SortVariants_Parsed()
+    {
+        var a = ListCommandOptions.FromArgs(["--sort", "size"]);
+        Assert.Equal("size", a.SortKey);
+
+        var b = ListCommandOptions.FromArgs(["--sort=date"]);
+        Assert.Equal("date", b.SortKey);
+
+        var c = ListCommandOptions.FromArgs(["--SORT", "time"]);
+        Assert.Equal("time", c.SortKey);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FromArgs_DescendingFlags_Parsed()
+    {
+        var a = ListCommandOptions.FromArgs(["--desc"]);
+        Assert.True(a.Descending);
+
+        var b = ListCommandOptions.FromArgs(["--reverse"]);
+        Assert.True(b.Descending);
+
+        var c = ListCommandOptions.FromArgs(["-r"]);
+        Assert.True(c.Descending);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FromArgs_ContainerAndPattern_OrderMatters()
+    {
+        var opts = ListCommandOptions.FromArgs(["docs", "*.txt"]);
+        Assert.Equal("docs", opts.Container);
+        Assert.Equal("*.txt", opts.Pattern);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FromArgs_PatternOnly_GlobDetected()
+    {
+        var a = ListCommandOptions.FromArgs(["*.log"]);
+        Assert.Null(a.Container);
+        Assert.Equal("*.log", a.Pattern);
+
+        var b = ListCommandOptions.FromArgs(["????.txt"]);
+        Assert.Null(b.Container);
+        Assert.Equal("????.txt", b.Pattern);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FromArgs_Mixed_WithSortAndDesc()
+    {
+        var opts = ListCommandOptions.FromArgs(["docs", "*.txt", "--sort", "date", "--desc"]);
+        Assert.Equal("docs", opts.Container);
+        Assert.Equal("*.txt", opts.Pattern);
+        Assert.Equal("date", opts.SortKey);
+        Assert.True(opts.Descending);
+    }
+}
+

--- a/src/AzStore.Terminal.Tests/Commands/ListCommandTests.cs
+++ b/src/AzStore.Terminal.Tests/Commands/ListCommandTests.cs
@@ -1,4 +1,6 @@
 using AzStore.Terminal.Commands;
+using AzStore.Core.Models.Session;
+using AzStore.Core.Services.Abstractions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
@@ -11,7 +13,8 @@ public class ListCommandTests
     public void Name_ReturnsList()
     {
         var logger = Substitute.For<ILogger<ListCommand>>();
-        var command = new ListCommand(logger);
+        var sessions = Substitute.For<ISessionManager>();
+        var command = new ListCommand(logger, sessions);
         
         Assert.Equal("list", command.Name);
     }
@@ -20,7 +23,8 @@ public class ListCommandTests
     public void Aliases_ContainsLs()
     {
         var logger = Substitute.For<ILogger<ListCommand>>();
-        var command = new ListCommand(logger);
+        var sessions = Substitute.For<ISessionManager>();
+        var command = new ListCommand(logger, sessions);
         
         Assert.Contains("ls", command.Aliases);
     }
@@ -29,7 +33,8 @@ public class ListCommandTests
     public void Description_IsNotEmpty()
     {
         var logger = Substitute.For<ILogger<ListCommand>>();
-        var command = new ListCommand(logger);
+        var sessions = Substitute.For<ISessionManager>();
+        var command = new ListCommand(logger, sessions);
         
         Assert.False(string.IsNullOrWhiteSpace(command.Description));
     }
@@ -38,23 +43,175 @@ public class ListCommandTests
     public async Task ExecuteAsync_ReturnsSuccessResult()
     {
         var logger = Substitute.For<ILogger<ListCommand>>();
-        var command = new ListCommand(logger);
+        var sessions = Substitute.For<ISessionManager>();
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var session = new Session("test", tempDir.FullName, "account123", Guid.NewGuid(), DateTime.UtcNow, DateTime.UtcNow);
+            sessions.GetActiveSession().Returns(session);
+
+            var command = new ListCommand(logger, sessions);
+            var result = await command.ExecuteAsync(Array.Empty<string>());
         
-        var result = await command.ExecuteAsync(Array.Empty<string>());
-        
-        Assert.True(result.Success);
-        Assert.False(result.ShouldExit);
-        Assert.NotNull(result.Message);
+            Assert.True(result.Success);
+            Assert.False(result.ShouldExit);
+            Assert.NotNull(result.Message);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
     }
 
     [Fact]
     public async Task ExecuteAsync_LogsDebugMessage()
     {
         var logger = Substitute.For<ILogger<ListCommand>>();
-        var command = new ListCommand(logger);
+        var sessions = Substitute.For<ISessionManager>();
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var session = new Session("test", tempDir.FullName, "account123", Guid.NewGuid(), DateTime.UtcNow, DateTime.UtcNow);
+            sessions.GetActiveSession().Returns(session);
+
+            var command = new ListCommand(logger, sessions);
+            await command.ExecuteAsync(Array.Empty<string>());
         
-        await command.ExecuteAsync(Array.Empty<string>());
-        
-        logger.Received(1).LogDebug("User requested file list");
+            logger.Received(1).LogDebug("User requested file list");
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoActiveSession_ReturnsError()
+    {
+        var logger = Substitute.For<ILogger<ListCommand>>();
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.GetActiveSession().Returns((Session?)null);
+
+        var command = new ListCommand(logger, sessions);
+        var result = await command.ExecuteAsync(Array.Empty<string>());
+
+        Assert.False(result.Success);
+        Assert.Contains("No active session", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptySessionDirectory_ReturnsFriendlyMessage()
+    {
+        var logger = Substitute.For<ILogger<ListCommand>>();
+        var sessions = Substitute.For<ISessionManager>();
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var session = new Session("mysession", tempDir.FullName, "account123", Guid.NewGuid(), DateTime.UtcNow, DateTime.UtcNow);
+            sessions.GetActiveSession().Returns(session);
+
+            var command = new ListCommand(logger, sessions);
+            var result = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.True(result.Success);
+            Assert.Contains("No files downloaded yet", result.Message);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ListsAndSortsByName_WithContainerAndGlob()
+    {
+        var logger = Substitute.For<ILogger<ListCommand>>();
+        var sessions = Substitute.For<ISessionManager>();
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var session = new Session("sessionA", tempDir.FullName, "account123", Guid.NewGuid(), DateTime.UtcNow, DateTime.UtcNow);
+            sessions.GetActiveSession().Returns(session);
+
+            // Create session root and files
+            var sessionRoot = Path.Combine(tempDir.FullName, "sessionA");
+            Directory.CreateDirectory(sessionRoot);
+            var cont1 = Path.Combine(sessionRoot, "docs");
+            var cont2 = Path.Combine(sessionRoot, "media");
+            Directory.CreateDirectory(cont1);
+            Directory.CreateDirectory(cont2);
+
+            var f1 = Path.Combine(cont1, "a.txt");
+            var f2 = Path.Combine(cont1, "b.log");
+            var f3 = Path.Combine(cont2, "clip.mp4");
+            await File.WriteAllTextAsync(f1, new string('x', 10));
+            await File.WriteAllTextAsync(f2, new string('y', 100));
+            await File.WriteAllBytesAsync(f3, new byte[5]);
+
+            File.SetLastWriteTime(f1, DateTime.Now.AddMinutes(-10));
+            File.SetLastWriteTime(f2, DateTime.Now.AddMinutes(-5));
+            File.SetLastWriteTime(f3, DateTime.Now.AddMinutes(-1));
+
+            var command = new ListCommand(logger, sessions);
+
+            // Container filter
+            var resultDocs = await command.ExecuteAsync(["docs"], default);
+            Assert.True(resultDocs.Success);
+            Assert.Contains("docs" + Path.DirectorySeparatorChar + "a.txt", resultDocs.Message);
+            Assert.Contains("docs" + Path.DirectorySeparatorChar + "b.log", resultDocs.Message);
+            Assert.DoesNotContain("media", resultDocs.Message);
+
+            // Glob filter
+            var resultTxt = await command.ExecuteAsync(["*.txt"], default);
+            Assert.True(resultTxt.Success);
+            Assert.Contains("a.txt", resultTxt.Message);
+            Assert.DoesNotContain("b.log", resultTxt.Message);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SortsBySizeAndDate_WithDesc()
+    {
+        var logger = Substitute.For<ILogger<ListCommand>>();
+        var sessions = Substitute.For<ISessionManager>();
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var session = new Session("sess", tempDir.FullName, "account123", Guid.NewGuid(), DateTime.UtcNow, DateTime.UtcNow);
+            sessions.GetActiveSession().Returns(session);
+
+            var sessionRoot = Path.Combine(tempDir.FullName, "sess");
+            Directory.CreateDirectory(sessionRoot);
+            var cont = Path.Combine(sessionRoot, "c1");
+            Directory.CreateDirectory(cont);
+
+            var fSmall = Path.Combine(cont, "small.bin");
+            var fLarge = Path.Combine(cont, "large.bin");
+            await File.WriteAllBytesAsync(fSmall, new byte[10]);
+            await File.WriteAllBytesAsync(fLarge, new byte[1000]);
+            File.SetLastWriteTime(fSmall, DateTime.Now.AddMinutes(-1));
+            File.SetLastWriteTime(fLarge, DateTime.Now.AddMinutes(-5));
+
+            var command = new ListCommand(logger, sessions);
+
+            var bySizeDesc = await command.ExecuteAsync(["--sort", "size", "--desc"], default);
+            Assert.True(bySizeDesc.Success);
+            var firstLine = bySizeDesc.Message!.Split('\n')[0];
+            Assert.Contains("large.bin", firstLine);
+
+            var byDate = await command.ExecuteAsync(["--sort=date"], default);
+            Assert.True(byDate.Success);
+            // Ascending: older first
+            var firstLineDate = byDate.Message!.Split('\n')[0];
+            Assert.Contains("large.bin", firstLineDate);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
     }
 }

--- a/src/AzStore.Terminal/Commands/ListCommand.cs
+++ b/src/AzStore.Terminal/Commands/ListCommand.cs
@@ -1,3 +1,6 @@
+using AzStore.Core.IO;
+using AzStore.Core.Services.Abstractions;
+using AzStore.Terminal.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace AzStore.Terminal.Commands;
@@ -5,21 +8,119 @@ namespace AzStore.Terminal.Commands;
 public class ListCommand : ICommand
 {
     private readonly ILogger<ListCommand> _logger;
+    private readonly ISessionManager _sessionManager;
 
     public string Name => "list";
     public string[] Aliases => ["ls"];
-    public string Description => "List downloaded files";
+    public string Description => "List downloaded files for current session";
 
-    public ListCommand(ILogger<ListCommand> logger)
+    public ListCommand(ILogger<ListCommand> logger, ISessionManager sessionManager)
     {
         _logger = logger;
+        _sessionManager = sessionManager;
     }
 
     public Task<CommandResult> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("User requested file list");
-        
-        // TODO: Implement actual file listing logic
-        return Task.FromResult(CommandResult.Ok("No files downloaded yet."));
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var session = _sessionManager.GetActiveSession();
+        if (session == null)
+            return Task.FromResult(CommandResult.Error("No active session. Use ':session list' and ':session switch <name>' to select a session."));
+
+        var sessionRoot = GetSessionRoot(session);
+        if (!Directory.Exists(sessionRoot))
+            return Task.FromResult(CommandResult.Ok("No files downloaded yet."));
+
+        var options = ListCommandOptions.FromArgs(args);
+
+        try
+        {
+            var files = EnumerateFiles(sessionRoot, cancellationToken).ToList();
+            if (files.Count == 0)
+                return Task.FromResult(CommandResult.Ok("No files downloaded yet."));
+
+            var filtered = FilterByContainer(files, sessionRoot, options.Container);
+            filtered = FilterByPattern(filtered, sessionRoot, options.Pattern);
+
+            var list = filtered.ToList();
+            if (list.Count == 0)
+            {
+                var msg = string.IsNullOrWhiteSpace(options.Container) && string.IsNullOrWhiteSpace(options.Pattern)
+                    ? "No files downloaded yet."
+                    : "No matching files.";
+
+                return Task.FromResult(CommandResult.Ok(msg));
+            }
+
+            var sorted = SortFiles(list, sessionRoot, options.SortKey, options.Descending);
+            var output = string.Join('\n', FormatLines(sorted, sessionRoot));
+            return Task.FromResult(CommandResult.Ok(output));
+        }
+        catch (OperationCanceledException)
+        {
+            return Task.FromResult(CommandResult.Error(":ls canceled"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list downloaded files");
+            return Task.FromResult(CommandResult.Error($":ls failed: {ex.Message}"));
+        }
     }
+
+    private static string GetSessionRoot(Core.Models.Session.Session session) =>
+        Path.Combine(session.Directory, PathHelper.CreateSafeDirectoryName(session.Name));
+
+    private static IEnumerable<FileInfo> EnumerateFiles(string root, CancellationToken ct)
+    {
+        foreach (var path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return new FileInfo(path);
+        }
+    }
+
+    private static IEnumerable<FileInfo> FilterByContainer(IEnumerable<FileInfo> files, string root, string? container)
+    {
+        if (string.IsNullOrWhiteSpace(container)) return files;
+        var safeContainer = PathHelper.CreateSafeDirectoryName(container);
+        return files.Where(fi =>
+        {
+            var rel = Path.GetRelativePath(root, fi.FullName);
+            var firstSep = rel.IndexOf(Path.DirectorySeparatorChar);
+            var firstSegment = firstSep >= 0 ? rel[..firstSep] : rel;
+            return string.Equals(firstSegment, safeContainer, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    private static IEnumerable<FileInfo> FilterByPattern(IEnumerable<FileInfo> files, string root, string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern)) return files;
+        var regex = Glob.ToRegex(pattern);
+        return files.Where(fi => regex.IsMatch(Path.GetRelativePath(root, fi.FullName)));
+    }
+
+    private static List<FileInfo> SortFiles(IEnumerable<FileInfo> files, string root, string sortKey, bool descending)
+    {
+        var ordered = sortKey.ToLowerInvariant() switch
+        {
+            "size" => files.OrderBy(f => f.Length),
+            "date" or "time" => files.OrderBy(f => f.LastWriteTimeUtc),
+            _ => files.OrderBy(f => Path.GetRelativePath(root, f.FullName), StringComparer.OrdinalIgnoreCase)
+        };
+
+        var list = ordered.ToList();
+        if (descending) list.Reverse();
+        return list;
+    }
+
+    private static IEnumerable<string> FormatLines(IEnumerable<FileInfo> files, string root) =>
+        files.Select(fi =>
+        {
+            var rel = Path.GetRelativePath(root, fi.FullName);
+            var size = TerminalUtils.FormatSize(fi.Length);
+            var date = fi.LastWriteTime.ToString("yyyy-MM-dd HH:mm");
+            return $"{rel}    {size,8}    {date}";
+        });
 }

--- a/src/AzStore.Terminal/Commands/ListCommandOptions.cs
+++ b/src/AzStore.Terminal/Commands/ListCommandOptions.cs
@@ -1,0 +1,64 @@
+namespace AzStore.Terminal.Commands;
+
+public sealed record ListCommandOptions(string? Container, string? Pattern, string SortKey, bool Descending)
+{
+    public static ListCommandOptions FromArgs(string[] args)
+    {
+        string? containerFilter = null;
+        string? pattern = null;
+        var sortKey = "name";
+        var descending = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (string.IsNullOrWhiteSpace(arg)) continue;
+
+            if (arg.StartsWith("--sort=", StringComparison.OrdinalIgnoreCase))
+            {
+                var eq = arg.IndexOf('=');
+                if (eq >= 0 && eq < arg.Length - 1)
+                {
+                    sortKey = arg[(eq + 1)..].Trim();
+                }
+                continue;
+            }
+
+            if (string.Equals(arg, "--sort", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length)
+                {
+                    sortKey = args[i + 1];
+                    i++;
+                }
+                continue;
+            }
+
+            if (string.Equals(arg, "--desc", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "--reverse", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "-r", StringComparison.Ordinal))
+            {
+                descending = true;
+                continue;
+            }
+
+            if (arg.Contains('*') || arg.Contains('?'))
+            {
+                pattern ??= arg.Trim();
+            }
+            else if (!arg.StartsWith('-'))
+            {
+                if (containerFilter is not null)
+                {
+                    pattern ??= arg.Trim();
+                }
+                else
+                {
+                    containerFilter = arg.Trim();
+                }
+            }
+        }
+
+        return new ListCommandOptions(containerFilter, pattern, sortKey, descending);
+    }
+}

--- a/src/AzStore.Terminal/Commands/SessionCommand.cs
+++ b/src/AzStore.Terminal/Commands/SessionCommand.cs
@@ -85,15 +85,15 @@ public class SessionCommand : ICommand
 
             if (string.IsNullOrEmpty(storageAccountName))
             {
-                var accounts = await _authService.GetStorageAccountsAsync(authResult.SubscriptionId.Value, cancellationToken);
-                if (!accounts.Any())
+                var accounts = (await _authService.GetStorageAccountsAsync(authResult.SubscriptionId.Value, cancellationToken)).ToList();
+                if (accounts.Count == 0)
                 {
                     return CommandResult.Error("No storage accounts found. Please authenticate first.");
                 }
 
-                if (accounts.Count() == 1)
+                if (accounts.Count == 1)
                 {
-                    storageAccountName = accounts.First().AccountName;
+                    storageAccountName = accounts[0].AccountName;
                 }
                 else
                 {
@@ -132,10 +132,10 @@ public class SessionCommand : ICommand
     {
         try
         {
-            var sessions = _sessionManager.GetAllSessions();
+            var sessions = _sessionManager.GetAllSessions().ToList();
             var activeSession = _sessionManager.GetActiveSession();
 
-            if (!sessions.Any())
+            if (sessions.Count == 0)
             {
                 return CommandResult.Ok("No sessions found. Use ':session create' to create a new session.");
             }

--- a/src/AzStore.Terminal/UI/BlobBrowserView.cs
+++ b/src/AzStore.Terminal/UI/BlobBrowserView.cs
@@ -165,7 +165,10 @@ public class BlobBrowserView : View
 
         if (_currentState != null && _currentState.SelectedIndex < _displayItems.Count)
         {
-            _listView!.SelectedItem = _currentState.SelectedIndex;
+            if (_listView != null)
+            {
+                _listView.SelectedItem = _currentState.SelectedIndex;
+            }
         }
     }
 

--- a/src/AzStore.Terminal/Utilities/Glob.cs
+++ b/src/AzStore.Terminal/Utilities/Glob.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+
+namespace AzStore.Terminal.Utilities;
+
+public static class Glob
+{
+    public static Regex ToRegex(string pattern, bool ignoreCase = true)
+    {
+        var escaped = Regex.Escape(pattern)
+            .Replace("\\*", ".*")
+            .Replace("\\?", ".");
+
+        var options = RegexOptions.Compiled | (ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
+        return new Regex($"^{escaped}$", options);
+    }
+}
+

--- a/src/AzStore.Terminal/Utilities/HelpTextGenerator.cs
+++ b/src/AzStore.Terminal/Utilities/HelpTextGenerator.cs
@@ -60,7 +60,7 @@ public class HelpTextGenerator
         sb.AppendLine("  :help    Show available commands");
         sb.AppendLine("  :exit    Exit application");
         sb.AppendLine("  :q       Quick exit");
-        sb.AppendLine("  :ls      List items in current location");
+        sb.AppendLine("  :ls      List downloaded files for current session");
         sb.AppendLine("  :download <item> Download specific item");
         sb.AppendLine();
 
@@ -228,7 +228,7 @@ public class HelpTextGenerator
         sb.AppendLine("  help         Show command help");
         sb.AppendLine("  exit, quit   Exit application");
         sb.AppendLine("  q            Quick exit");
-        sb.AppendLine("  ls, list     List current items");
+        sb.AppendLine("  ls, list     List downloaded files");
         sb.AppendLine("  download     Download selected or specified item");
         sb.AppendLine("  session      Show session information");
         sb.AppendLine();


### PR DESCRIPTION
- Extract argument parsing into ListCommandOptions.FromArgs with dedicated tests
- Decompose ExecuteAsync into focused helpers; honor CancellationToken during enumeration
- Add Utilities.Glob with compiled, case-insensitive glob-to-regex
- Fix lazy enumeration double-pass by materializing once before checks
- Keep behavior and output identical; all unit tests pass

Tests:
- Add ListCommandOptionsTests covering defaults, sort variants, desc flags, globs, arg ordering

Docs:
- Update AGENTS.md with lessons learned: parsing factory pattern, case-insensitive flags, cancellation, enumeration materialization, utility reuse, decomposition, one-type-per-file, parsing tests, and VSTest guidance