### PR TITLE
feat(exit): implement graceful exit with confirmation and force (:q!/…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,21 @@ public class MyCommand : ICommand
 }
 ```
 
+### Exit & Cleanup
+- Commands: `:exit`, `:q` for normal shutdown; `:exit!`, `:q!` for forced shutdown.
+- Force parsing: The REPL strips `!` and appends `--force` to args; commands check for `--force` to bypass prompts.
+- REPL exit: When a command returns `ShouldExit`, the REPL loop breaks and the hosted service triggers `StopApplication()`.
+- Downloads: `IDownloadActivity` tracks active downloads; normal exit prompts if any are active, force exit skips confirmation.
+- Sessions: `ExitCommand` attempts `ISessionManager.SaveSessionsAsync()` before exit (best effort).
+
+### REPL Parsing Pattern
+- Commands must start with `:`. The first token is the command name; remaining tokens are args.
+- A trailing `!` on the command token denotes force mode and results in `--force` being appended to args.
+
+### Download Activity
+- Use `IDownloadActivity.Begin()` to mark the lifetime of a download; dispose to decrement.
+- Check `HasActiveDownloads`/`ActiveCount` when deciding to prompt on exit or display status to the user.
+
 ## Development Practices
 
 ### Testing Strategy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,21 @@ public class MyCommand : ICommand
 }
 ```
 
+### Exit & Cleanup
+- Commands: `:exit`, `:q` for normal shutdown; `:exit!`, `:q!` for forced shutdown.
+- Force parsing: The REPL strips `!` and appends `--force` to args; commands check for `--force` to bypass prompts.
+- REPL exit: When a command returns `ShouldExit`, the REPL loop breaks and the hosted service triggers `StopApplication()`.
+- Downloads: `IDownloadActivity` tracks active downloads; normal exit prompts if any are active, force exit skips confirmation.
+- Sessions: `ExitCommand` attempts `ISessionManager.SaveSessionsAsync()` before exit (best effort).
+
+### REPL Parsing Pattern
+- Commands must start with `:`. The first token is the command name; remaining tokens are args.
+- A trailing `!` on the command token denotes force mode and results in `--force` being appended to args.
+
+### Download Activity
+- Use `IDownloadActivity.Begin()` to mark the lifetime of a download; dispose to decrement.
+- Check `HasActiveDownloads`/`ActiveCount` when deciding to prompt on exit or display status to the user.
+
 ## Development Practices
 
 ### Testing Strategy

--- a/src/AzStore.CLI/ServiceCollectionExtensions.cs
+++ b/src/AzStore.CLI/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class ServiceCollectionExtensions
             var settings = provider.GetRequiredService<IOptions<AzStoreSettings>>();
             return new HelpTextGenerator(settings.Value.KeyBindings);
         });
+        services.AddSingleton<IDownloadActivity, DownloadActivity>();
         services.AddSingleton<IReplEngine, ReplEngine>();
         services.AddSingleton<IInputHandler>(provider =>
         {

--- a/src/AzStore.Terminal.Tests/Repl/ReplEngineExitTests.cs
+++ b/src/AzStore.Terminal.Tests/Repl/ReplEngineExitTests.cs
@@ -1,0 +1,83 @@
+using AzStore.Configuration;
+using AzStore.Core.Services.Abstractions;
+using AzStore.Terminal.Commands;
+using AzStore.Terminal.Navigation;
+using AzStore.Terminal.Repl;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AzStore.Terminal.Tests;
+
+public class ReplEngineExitTests
+{
+    private static IOptions<AzStoreSettings> CreateMockSettings()
+    {
+        var settings = new AzStoreSettings();
+        var options = Substitute.For<IOptions<AzStoreSettings>>();
+        options.Value.Returns(settings);
+        return options;
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ProcessInputAsync_ExitCommand_ReturnsShouldExit()
+    {
+        var settings = CreateMockSettings();
+        var logger = Substitute.For<ILogger<ReplEngine>>();
+        var sessionManager = Substitute.For<ISessionManager>();
+        var navigationEngine = Substitute.For<INavigationEngine>();
+
+        var exitCmd = Substitute.For<ICommand>();
+        exitCmd.Name.Returns("exit");
+        exitCmd.Aliases.Returns(Array.Empty<string>());
+        exitCmd.Description.Returns("Exit");
+        exitCmd.ExecuteAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(CommandResult.Exit()));
+
+        var registry = Substitute.For<ICommandRegistry>();
+        registry.FindCommand("exit").Returns(exitCmd);
+
+        var repl = new ReplEngine(settings, logger, registry, sessionManager, navigationEngine);
+
+        var shouldExit = await repl.ProcessInputAsync(":exit");
+
+        Assert.True(shouldExit);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ProcessInputAsync_ExitForce_AppendsForceArg()
+    {
+        var settings = CreateMockSettings();
+        var logger = Substitute.For<ILogger<ReplEngine>>();
+        var sessionManager = Substitute.For<ISessionManager>();
+        var navigationEngine = Substitute.For<INavigationEngine>();
+
+        string[]? capturedArgs = null;
+        var exitCmd = Substitute.For<ICommand>();
+        exitCmd.Name.Returns("exit");
+        exitCmd.Aliases.Returns(new[] { "q" });
+        exitCmd.Description.Returns("Exit");
+        exitCmd.ExecuteAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                capturedArgs = ci.ArgAt<string[]>(0);
+                return Task.FromResult(CommandResult.Exit());
+            });
+
+        var registry = Substitute.For<ICommandRegistry>();
+        registry.FindCommand("exit").Returns(exitCmd);
+        registry.FindCommand("q").Returns(exitCmd); // alias lookup
+        registry.FindCommand(":exit").Returns((ICommand?)null); // ensure lookup uses parsed name
+
+        var repl = new ReplEngine(settings, logger, registry, sessionManager, navigationEngine);
+
+        var shouldExit = await repl.ProcessInputAsync(":q!");
+
+        Assert.True(shouldExit);
+        Assert.NotNull(capturedArgs);
+        Assert.Contains("--force", capturedArgs!);
+    }
+}

--- a/src/AzStore.Terminal/AzStore.Terminal.csproj
+++ b/src/AzStore.Terminal/AzStore.Terminal.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
     <PackageReference Include="Terminal.Gui" Version="2.0.0-alpha.*" />
   </ItemGroup>
 

--- a/src/AzStore.Terminal/Commands/ExitCommand.cs
+++ b/src/AzStore.Terminal/Commands/ExitCommand.cs
@@ -1,23 +1,70 @@
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using AzStore.Core.Services.Abstractions;
+using AzStore.Terminal.UI;
+using AzStore.Terminal.Utilities;
 
 namespace AzStore.Terminal.Commands;
 
 public class ExitCommand : ICommand
 {
     private readonly ILogger<ExitCommand> _logger;
+    private readonly ISessionManager _sessionManager;
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly IDownloadActivity _downloadActivity;
 
     public string Name => "exit";
-    public string[] Aliases => ["q"];
-    public string Description => "Exit the application";
+    public string[] Aliases => ["q", "q!", "exit!"];
+    public string Description => "Exit the application (:q, :q! for force)";
 
-    public ExitCommand(ILogger<ExitCommand> logger)
+    public ExitCommand(ILogger<ExitCommand> logger, ISessionManager sessionManager, IHostApplicationLifetime lifetime, IDownloadActivity downloadActivity)
     {
         _logger = logger;
+        _sessionManager = sessionManager;
+        _lifetime = lifetime;
+        _downloadActivity = downloadActivity;
     }
 
-    public Task<CommandResult> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
+    public async Task<CommandResult> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("User initiated exit via command");
-        return Task.FromResult(CommandResult.Exit("Goodbye!"));
+
+        var force = args.Any(a => string.Equals(a, "--force", StringComparison.OrdinalIgnoreCase));
+
+        if (!force && _downloadActivity.HasActiveDownloads)
+        {
+            var count = _downloadActivity.ActiveCount;
+            var result = TerminalConfirmation.ShowConfirmation(
+                message: count == 1
+                    ? "A download is in progress. Exiting will cancel it. Exit anyway?"
+                    : $"{count} downloads are in progress. Exiting will cancel them. Exit anyway?",
+                defaultChoice: 'N');
+
+            if (result != ConfirmationResult.Yes)
+            {
+                _logger.LogInformation("Exit cancelled by user");
+                return CommandResult.Ok("Exit cancelled.");
+            }
+        }
+
+        try
+        {
+            await _sessionManager.SaveSessionsAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to save session metadata during exit");
+        }
+
+        try
+        {
+            _lifetime.StopApplication();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "StopApplication threw (can be ignored if host already stopping)");
+        }
+
+        return CommandResult.Exit("Goodbye!");
     }
 }

--- a/src/AzStore.Terminal/Utilities/DownloadActivity.cs
+++ b/src/AzStore.Terminal/Utilities/DownloadActivity.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+
+namespace AzStore.Terminal.Utilities;
+
+public sealed class DownloadActivity : IDownloadActivity
+{
+    private int _active;
+
+    public int ActiveCount => Volatile.Read(ref _active);
+    public bool HasActiveDownloads => ActiveCount > 0;
+
+    public IDisposable Begin()
+    {
+        Interlocked.Increment(ref _active);
+        return new Scope(this);
+    }
+
+    private void End()
+    {
+        Interlocked.Decrement(ref _active);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private DownloadActivity? _owner;
+
+        public Scope(DownloadActivity owner) => _owner = owner;
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            owner?.End();
+        }
+    }
+}
+

--- a/src/AzStore.Terminal/Utilities/IDownloadActivity.cs
+++ b/src/AzStore.Terminal/Utilities/IDownloadActivity.cs
@@ -1,0 +1,13 @@
+namespace AzStore.Terminal.Utilities;
+
+public interface IDownloadActivity
+{
+    int ActiveCount { get; }
+    bool HasActiveDownloads { get; }
+
+    /// <summary>
+    /// Marks the beginning of a download scope. Dispose the returned object to decrement.
+    /// </summary>
+    IDisposable Begin();
+}
+

--- a/src/AzStore.Terminal/Utilities/NullDownloadActivity.cs
+++ b/src/AzStore.Terminal/Utilities/NullDownloadActivity.cs
@@ -1,0 +1,11 @@
+namespace AzStore.Terminal.Utilities;
+
+public sealed class NullDownloadActivity : IDownloadActivity
+{
+    private sealed class Nop : IDisposable { public void Dispose() { } }
+
+    public int ActiveCount => 0;
+    public bool HasActiveDownloads => false;
+    public IDisposable Begin() => new Nop();
+}
+


### PR DESCRIPTION
…:exit!)\n\n- Add IDownloadActivity to track active downloads\n- Prompt on exit if downloads active; skip with --force\n- REPL parses :q!/:exit! and breaks loop on exit\n- ExitCommand saves sessions and requests host stop\n- Wire DI + add tests\n\nDocs: Update CLAUDE.md and AGENTS.md with exit/cleanup notes\n\nCloses #21