### PR TITLE
feat(terminal): Interactive storage account picker with fuzzy search;…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,12 @@ The project uses a layered architecture with the following components:
 
 Hierarchical configuration: appsettings.json → TOML config (`%APPDATA%\azstore\azstore.toml` or `~/.config/azstore/azstore.toml`) → `AZSTORE_*` environment variables. Covers logging, themes, key bindings, file conflicts, and session management.
 
+- Terminal selection (multi-account picker):
+  - `AzStore:Selection:enableFuzzySearch` (bool, default true)
+  - `AzStore:Selection:maxVisibleItems` (int, default 15)
+  - `AzStore:Selection:highlightMatches` (bool, default true)
+  - `AzStore:Selection:pickerTimeoutMs` (int?, default null)
+
 ## Command System Architecture
 
 The application uses an extensible command pattern with dependency injection for maximum testability and maintainability.
@@ -54,6 +60,7 @@ The application uses an extensible command pattern with dependency injection for
 - **CommandRegistry**: Service that discovers and provides command lookup functionality
 - **CommandResult**: Standardized result type with success status, messages, and exit flags
 - **Built-in Commands**: ExitCommand, HelpCommand, ListCommand
+- **Interactive Selection**: `IAccountSelectionService` renders a non-destructive overlay picker for choosing items like storage accounts.
 
 ### Adding New Commands
 1. Create a class implementing `ICommand` interface
@@ -225,3 +232,8 @@ Complete development environment setup:
 - **Architecture**: Interface extraction, improved DI patterns, command registry with lazy loading
 - **Testing**: Migrated from FluentAssertions to standard xUnit assertions, 104+ tests with comprehensive edge case coverage
 - **Quality**: Modern C# 12 syntax, proper async/await patterns, cross-platform compatibility
+### Account Selection (Issue #55)
+- Non-destructive console overlay for multi-account scenarios using `IAccountSelectionService`.
+- Fuzzy search with lightweight subsequence/substring matcher (`SimpleFuzzyMatcher`).
+- VIM-like navigation supported: `j/k`, `gg/G`, arrows, PageUp/PageDown, Enter/Esc).
+- Selection is used when creating a session if multiple accounts are available.

--- a/src/AzStore.CLI/ServiceCollectionExtensions.cs
+++ b/src/AzStore.CLI/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using AzStore.Terminal.Navigation;
 using AzStore.Terminal.Repl;
 using AzStore.Terminal.UI;
 using AzStore.Terminal.Utilities;
+using AzStore.Terminal.Selection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -44,6 +45,8 @@ public static class ServiceCollectionExtensions
         });
         services.AddSingleton<IDownloadActivity, DownloadActivity>();
         services.AddSingleton<IReplEngine, ReplEngine>();
+        services.AddSingleton<IFuzzyMatcher, SimpleFuzzyMatcher>();
+        services.AddSingleton<IAccountSelectionService, ConsoleAccountSelectionService>();
         services.AddSingleton<IInputHandler>(provider =>
         {
             var logger = provider.GetRequiredService<ILogger<InputHandler>>();

--- a/src/AzStore.Configuration/Settings.cs
+++ b/src/AzStore.Configuration/Settings.cs
@@ -28,6 +28,9 @@ public class AzStoreSettings
     [Required]
     public LoggingSettings Logging { get; set; } = new();
 
+    [Required]
+    public TerminalSelectionOptions Selection { get; set; } = new();
+
     private static string GetDefaultSessionsDirectory()
     {
         var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);

--- a/src/AzStore.Configuration/TerminalSelectionOptions.cs
+++ b/src/AzStore.Configuration/TerminalSelectionOptions.cs
@@ -1,0 +1,10 @@
+namespace AzStore.Configuration;
+
+public class TerminalSelectionOptions
+{
+    public bool EnableFuzzySearch { get; set; } = true;
+    public int MaxVisibleItems { get; set; } = 15; // default within 12–20 range
+    public bool HighlightMatches { get; set; } = true;
+    public int? PickerTimeoutMs { get; set; } = null;
+}
+

--- a/src/AzStore.Terminal.Tests/Commands/SessionCommandCreateTests.cs
+++ b/src/AzStore.Terminal.Tests/Commands/SessionCommandCreateTests.cs
@@ -1,0 +1,94 @@
+using AzStore.Configuration;
+using AzStore.Core.Models.Authentication;
+using AzStore.Core.Models.Session;
+using AzStore.Core.Services.Abstractions;
+using AzStore.Terminal.Commands;
+using AzStore.Terminal.Selection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AzStore.Terminal.Tests;
+
+public class SessionCommandCreateTests
+{
+    private static (SessionCommand Cmd, ISessionManager Sessions, IAuthenticationService Auth, IAccountSelectionService Picker)
+        Create(
+            IEnumerable<StorageAccountInfo> accounts,
+            StorageAccountInfo? pickerSelection = null)
+    {
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.CreateSessionAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(new Session(ci.ArgAt<string>(0), "/tmp", ci.ArgAt<string>(1), ci.ArgAt<Guid>(2), DateTime.UtcNow, DateTime.UtcNow)));
+
+        var auth = Substitute.For<IAuthenticationService>();
+        var subId = Guid.NewGuid();
+        auth.GetCurrentAuthenticationAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthenticationResult.Successful("***", subscriptionId: subId));
+        auth.GetStorageAccountsAsync(subId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(accounts));
+
+        var logger = Substitute.For<ILogger<SessionCommand>>();
+        var settings = Options.Create(new AzStoreSettings());
+
+        var picker = Substitute.For<IAccountSelectionService>();
+        picker.PickAsync(Arg.Any<IReadOnlyList<StorageAccountInfo>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(pickerSelection));
+
+        var cmd = new SessionCommand(sessions, auth, logger, settings, picker);
+        return (cmd, sessions, auth, picker);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public async Task Create_NoAccounts_ReturnsError()
+    {
+        var (cmd, _, _, _) = Create(Array.Empty<StorageAccountInfo>());
+        var result = await cmd.ExecuteAsync(["create", "mysess"], CancellationToken.None);
+        Assert.False(result.Success);
+        Assert.Contains("No storage accounts", result.Message);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public async Task Create_SingleAccount_AutoSelects()
+    {
+        var acc = new StorageAccountInfo("acct1", null, Guid.NewGuid(), "rg", new Uri("https://a/"));
+        var (cmd, sessions, _, _) = Create(new[] { acc });
+        var result = await cmd.ExecuteAsync(["create", "mysess"], CancellationToken.None);
+        Assert.True(result.Success);
+        await sessions.Received(1).CreateSessionAsync("mysess", "acct1", Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public async Task Create_MultipleAccounts_PickerSelects_Proceeds()
+    {
+        var accs = new[]
+        {
+            new StorageAccountInfo("a1", null, Guid.NewGuid(), "rg1", new Uri("https://a/")),
+            new StorageAccountInfo("a2", null, Guid.NewGuid(), "rg2", new Uri("https://b/")),
+        };
+        var (cmd, sessions, _, _) = Create(accs, accs[1]);
+        var result = await cmd.ExecuteAsync(["create", "mysess"], CancellationToken.None);
+        Assert.True(result.Success);
+        await sessions.Received(1).CreateSessionAsync("mysess", "a2", Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public async Task Create_MultipleAccounts_PickerCancelled_ReturnsOkWithNotice()
+    {
+        var accs = new[]
+        {
+            new StorageAccountInfo("a1", null, Guid.NewGuid(), "rg1", new Uri("https://a/")),
+            new StorageAccountInfo("a2", null, Guid.NewGuid(), "rg2", new Uri("https://b/")),
+        };
+        var (cmd, sessions, _, _) = Create(accs, null);
+        var result = await cmd.ExecuteAsync(["create", "mysess"], CancellationToken.None);
+        Assert.True(result.Success);
+        Assert.Contains("Selection cancelled", result.Message);
+        await sessions.DidNotReceive().CreateSessionAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/AzStore.Terminal.Tests/Selection/AccountPickerEngineTests.cs
+++ b/src/AzStore.Terminal.Tests/Selection/AccountPickerEngineTests.cs
@@ -1,0 +1,66 @@
+using AzStore.Configuration;
+using AzStore.Core.Models.Authentication;
+using AzStore.Terminal.Selection;
+using AzStore.Terminal.Utilities;
+using Xunit;
+
+namespace AzStore.Terminal.Tests;
+
+public class AccountPickerEngineTests
+{
+    private static (AccountPickerEngine Engine, List<StorageAccountInfo> Accounts) CreateEngine(int count = 30)
+    {
+        var accounts = Enumerable.Range(1, count)
+            .Select(i => new StorageAccountInfo($"acct{i:000}", null, Guid.NewGuid(), $"rg{i}", new Uri($"https://acct{i}.blob.core.windows.net/")))
+            .ToList();
+        var matcher = new SimpleFuzzyMatcher();
+        var options = new TerminalSelectionOptions { MaxVisibleItems = 5, EnableFuzzySearch = true };
+        var engine = new AccountPickerEngine(accounts, matcher, options);
+        return (engine, accounts);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void MoveDown_And_Window_Adjusts()
+    {
+        var (engine, _) = CreateEngine();
+
+        Assert.Equal(0, engine.Index);
+        Assert.Equal((0, 5), engine.VisibleWindow());
+
+        for (int i = 0; i < 6; i++) engine.MoveDown();
+        Assert.Equal(6, engine.Index);
+        var (start, end) = engine.VisibleWindow();
+        Assert.True(engine.Index >= start && engine.Index < end);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void Top_And_Bottom_Work()
+    {
+        var (engine, accounts) = CreateEngine();
+        engine.Bottom();
+        Assert.Equal(accounts.Count - 1, engine.Index);
+        engine.Top();
+        Assert.Equal(0, engine.Index);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void Fuzzy_Substring_Ranks_Highest()
+    {
+        var accounts = new List<StorageAccountInfo>
+        {
+            new("strgacct", null, Guid.NewGuid(), "rg1", new Uri("https://a/")),
+            new("mystorage", null, Guid.NewGuid(), "rg2", new Uri("https://b/")),
+            new("s-t-r-g-a-c-c-t", null, Guid.NewGuid(), "rg3", new Uri("https://c/")),
+        };
+        var engine = new AccountPickerEngine(accounts, new SimpleFuzzyMatcher(), new TerminalSelectionOptions { EnableFuzzySearch = true });
+
+        engine.TypeChar('s'); engine.TypeChar('t'); engine.TypeChar('o'); engine.TypeChar('r');
+
+        Assert.True(engine.Filtered.Count > 0);
+        Assert.Equal("mystorage", engine.Filtered[0].Item.AccountName);
+    }
+}
+

--- a/src/AzStore.Terminal.Tests/Utilities/SimpleFuzzyMatcherTests.cs
+++ b/src/AzStore.Terminal.Tests/Utilities/SimpleFuzzyMatcherTests.cs
@@ -1,0 +1,46 @@
+using AzStore.Terminal.Utilities;
+using Xunit;
+
+namespace AzStore.Terminal.Tests;
+
+public class SimpleFuzzyMatcherTests
+{
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void MatchAndRank_EmptyQuery_ReturnsAllWithZeroScore()
+    {
+        var matcher = new SimpleFuzzyMatcher();
+        var items = new[] { "alpha", "beta" };
+
+        var results = matcher.MatchAndRank(items, s => new[] { s }, "").ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal(0, r.Score));
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void MatchAndRank_SubstringVsSubsequence_PrioritizesSubstring()
+    {
+        var matcher = new SimpleFuzzyMatcher();
+        var items = new[] { "strgacct", "mystorage", "s-t-r-g-a-c-c-t" };
+
+        var results = matcher.MatchAndRank(items, s => new[] { s }, "stor").OrderByDescending(r => r.Score).ToList();
+
+        Assert.Equal("mystorage", results[0].Item);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void MatchAndRank_CaseInsensitive_Works()
+    {
+        var matcher = new SimpleFuzzyMatcher();
+        var items = new[] { "MyStorage", "other" };
+
+        var results = matcher.MatchAndRank(items, s => new[] { s }, "storage").ToList();
+
+        Assert.Single(results);
+        Assert.Equal("MyStorage", results[0].Item);
+    }
+}
+

--- a/src/AzStore.Terminal/Selection/AccountPickerEngine.cs
+++ b/src/AzStore.Terminal/Selection/AccountPickerEngine.cs
@@ -1,0 +1,140 @@
+using AzStore.Configuration;
+using AzStore.Core.Models.Authentication;
+using AzStore.Terminal.Utilities;
+
+namespace AzStore.Terminal.Selection;
+
+public class AccountPickerEngine
+{
+    private readonly IReadOnlyList<StorageAccountInfo> _all;
+    private readonly IFuzzyMatcher _matcher;
+    private readonly TerminalSelectionOptions _options;
+
+    public string Query { get; private set; } = string.Empty;
+    public int Index { get; private set; }
+    public int WindowStart { get; private set; }
+    public int MaxVisible { get; }
+    public List<FuzzyMatchResult<StorageAccountInfo>> Filtered { get; private set; }
+
+    public AccountPickerEngine(IReadOnlyList<StorageAccountInfo> accounts, IFuzzyMatcher matcher, TerminalSelectionOptions options)
+    {
+        _all = accounts;
+        _matcher = matcher;
+        _options = options;
+        MaxVisible = Math.Max(5, options.MaxVisibleItems);
+        Filtered = accounts.Select(a => new FuzzyMatchResult<StorageAccountInfo>(a, 0))
+            .OrderBy(a => a.Item.AccountName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        Index = Filtered.Count > 0 ? 0 : -1;
+        WindowStart = 0;
+    }
+
+    public void TypeChar(char c)
+    {
+        if (!char.IsControl(c))
+        {
+            Query += c;
+            ApplyFilter();
+        }
+    }
+
+    public void Backspace()
+    {
+        if (Query.Length > 0)
+        {
+            Query = Query[..^1];
+            ApplyFilter();
+        }
+    }
+
+    public void MoveDown()
+    {
+        if (Filtered.Count == 0) return;
+        Index = Math.Min(Index + 1, Filtered.Count - 1);
+        EnsureWindow();
+    }
+
+    public void MoveUp()
+    {
+        if (Filtered.Count == 0) return;
+        Index = Math.Max(Index - 1, 0);
+        EnsureWindow();
+    }
+
+    public void PageDown()
+    {
+        if (Filtered.Count == 0) return;
+        Index = Math.Min(Index + MaxVisible, Filtered.Count - 1);
+        EnsureWindow();
+    }
+
+    public void PageUp()
+    {
+        if (Filtered.Count == 0) return;
+        Index = Math.Max(Index - MaxVisible, 0);
+        EnsureWindow();
+    }
+
+    public void Top()
+    {
+        if (Filtered.Count == 0) return;
+        Index = 0;
+        EnsureWindow();
+    }
+
+    public void Bottom()
+    {
+        if (Filtered.Count == 0) return;
+        Index = Filtered.Count - 1;
+        EnsureWindow();
+    }
+
+    public StorageAccountInfo? Current()
+    {
+        if (Index < 0 || Index >= Filtered.Count) return null;
+        return Filtered[Index].Item;
+    }
+
+    public (int start, int end) VisibleWindow()
+    {
+        var end = Math.Min(Filtered.Count, WindowStart + MaxVisible);
+        return (WindowStart, end);
+    }
+
+    private void ApplyFilter()
+    {
+        if (_options.EnableFuzzySearch && Query.Length > 0)
+        {
+            Filtered = _matcher
+                .MatchAndRank(_all, a => [a.AccountName, a.ResourceGroupName ?? string.Empty, a.SubscriptionId?.ToString() ?? string.Empty], Query)
+                .OrderByDescending(r => r.Score)
+                .ThenBy(r => r.Item.AccountName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        else
+        {
+            Filtered = _all.Select(a => new FuzzyMatchResult<StorageAccountInfo>(a, 0))
+                .OrderBy(a => a.Item.AccountName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        if (Filtered.Count == 0)
+        {
+            Index = -1;
+            WindowStart = 0;
+            return;
+        }
+
+        if (Index < 0) Index = 0;
+        if (Index >= Filtered.Count) Index = Filtered.Count - 1;
+        EnsureWindow();
+    }
+
+    private void EnsureWindow()
+    {
+        if (Index < 0) { WindowStart = 0; return; }
+        if (Index < WindowStart) WindowStart = Index;
+        if (Index >= WindowStart + MaxVisible) WindowStart = Math.Max(0, Index - MaxVisible + 1);
+    }
+}
+

--- a/src/AzStore.Terminal/Selection/ConsoleAccountSelectionService.cs
+++ b/src/AzStore.Terminal/Selection/ConsoleAccountSelectionService.cs
@@ -1,0 +1,223 @@
+using AzStore.Configuration;
+using AzStore.Core.Models.Authentication;
+using AzStore.Terminal.Input;
+using AzStore.Terminal.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AzStore.Terminal.Selection;
+
+public class ConsoleAccountSelectionService : IAccountSelectionService
+{
+    private readonly ILogger<ConsoleAccountSelectionService> _logger;
+    private readonly KeyBindings _keyBindings;
+    private readonly TerminalSelectionOptions _options;
+    private readonly IFuzzyMatcher _matcher;
+
+    public ConsoleAccountSelectionService(
+        ILogger<ConsoleAccountSelectionService> logger,
+        IOptions<AzStoreSettings> settings,
+        IFuzzyMatcher matcher)
+    {
+        _logger = logger;
+        _keyBindings = settings.Value.KeyBindings;
+        _options = settings.Value.Selection;
+        _matcher = matcher;
+    }
+
+    public async Task<StorageAccountInfo?> PickAsync(IReadOnlyList<StorageAccountInfo> accounts, CancellationToken cancellationToken = default)
+    {
+        if (accounts.Count == 0)
+        {
+            WriteError("No storage accounts found.");
+            return null;
+        }
+
+        if (accounts.Count == 1)
+        {
+            _logger.LogInformation("Single storage account available: {Account}", accounts[0].AccountName);
+            return accounts[0];
+        }
+
+        _logger.LogWarning("Multiple storage accounts discovered: {Count}", accounts.Count);
+
+        var engine = new AccountPickerEngine(accounts, _matcher, _options);
+        var maxVisible = engine.MaxVisible;
+
+        var startTime = _options.PickerTimeoutMs.HasValue ? DateTime.UtcNow : (DateTime?)null;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_options.PickerTimeoutMs.HasValue && startTime.HasValue && (DateTime.UtcNow - startTime.Value).TotalMilliseconds > _options.PickerTimeoutMs.Value)
+            {
+                _logger.LogInformation("Account picker timed out after {Ms} ms", _options.PickerTimeoutMs);
+                WriteInfo("Selection cancelled (timeout)");
+                return null;
+            }
+
+            DrawOverlay(engine.Filtered, engine.Query, engine.Index, engine.WindowStart, maxVisible);
+
+            if (!Console.KeyAvailable)
+            {
+                await Task.Delay(10, cancellationToken);
+                continue;
+            }
+
+            var key = Console.ReadKey(intercept: true);
+            startTime = _options.PickerTimeoutMs.HasValue ? DateTime.UtcNow : (DateTime?)null;
+
+            if (key.Key == ConsoleKey.Escape)
+            {
+                _logger.LogInformation("User cancelled account selection");
+                ClearOverlay(maxVisible + 5);
+                WriteInfo("Selection cancelled");
+                return null;
+            }
+
+            if (key.Key == ConsoleKey.Enter)
+            {
+                if (engine.Filtered.Count == 0) continue;
+                var chosen = engine.Current();
+                if (chosen == null) continue;
+                _logger.LogInformation("User selected storage account: {Account} ({SubscriptionId})", chosen.AccountName, chosen.SubscriptionId);
+                ClearOverlay(maxVisible + 5);
+                return chosen;
+            }
+
+            // Navigation keys: arrows, j/k, gg/G
+            if (key.Key == ConsoleKey.DownArrow || key.KeyChar == SafeChar(_keyBindings.MoveDown))
+            {
+                engine.MoveDown();
+            }
+            else if (key.Key == ConsoleKey.UpArrow || key.KeyChar == SafeChar(_keyBindings.MoveUp))
+            {
+                engine.MoveUp();
+            }
+            else if (key.Key == ConsoleKey.PageDown)
+            {
+                engine.PageDown();
+            }
+            else if (key.Key == ConsoleKey.PageUp)
+            {
+                engine.PageUp();
+            }
+            else if (key.KeyChar == SafeChar(_keyBindings.Bottom))
+            {
+                engine.Bottom();
+            }
+            else if (MatchesTopSequence(key))
+            {
+                engine.Top();
+            }
+            else if (!char.IsControl(key.KeyChar))
+            {
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    engine.Backspace();
+                }
+                else
+                {
+                    engine.TypeChar(key.KeyChar);
+                }
+            }
+
+            // clamp and adjust window will occur in next loop before draw
+        }
+    }
+
+    private static char SafeChar(string s) => string.IsNullOrEmpty(s) ? '\0' : s[^1];
+
+    private bool MatchesTopSequence(ConsoleKeyInfo key)
+    {
+        // crude handling for 'gg' top navigation: if user presses 'g' followed by 'g' quickly
+        if (string.Equals(_keyBindings.Top, "gg", StringComparison.Ordinal))
+        {
+            if (key.KeyChar == 'g')
+            {
+                if (Console.KeyAvailable)
+                {
+                    var next = Console.ReadKey(intercept: true);
+                    if (next.KeyChar == 'g') return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void DrawOverlay(List<FuzzyMatchResult<StorageAccountInfo>> rows, string query, int index, int windowStart, int maxVisible)
+    {
+        var header = $"Select storage account (type to filter, Enter=select, Esc=cancel)";
+        Console.WriteLine();
+        Console.WriteLine(header);
+        Console.WriteLine($"Filter: {query}");
+
+        var end = Math.Min(rows.Count, windowStart + maxVisible);
+        for (int i = windowStart; i < end; i++)
+        {
+            var item = rows[i].Item;
+            var prefix = (i == index) ? "> " : "  ";
+            var line = $"{item.AccountName}  [{item.SubscriptionId}]  {item.ResourceGroupName ?? ""}";
+            line = Truncate(line, Console.WindowWidth - 4);
+
+            // write with optional highlighting of first substring occurrence
+            if (_options.HighlightMatches && !string.IsNullOrEmpty(query))
+            {
+                var idx = line.IndexOf(query, StringComparison.OrdinalIgnoreCase);
+                if (idx >= 0)
+                {
+                    var before = line[..idx];
+                    var match = line.Substring(idx, Math.Min(query.Length, Math.Max(0, line.Length - idx)));
+                    var after = line[(idx + match.Length)..];
+
+                    Console.Write(prefix);
+                    Console.Write(before);
+                    var c = Console.ForegroundColor;
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.Write(match);
+                    Console.ForegroundColor = c;
+                    Console.WriteLine(after);
+                    continue;
+                }
+            }
+
+            Console.WriteLine(prefix + line);
+        }
+
+        // clear remaining area if fewer than maxVisible
+        for (int i = end; i < windowStart + maxVisible; i++)
+        {
+            Console.WriteLine("~");
+        }
+
+        Console.WriteLine();
+    }
+
+    private void ClearOverlay(int lines)
+    {
+        // Move cursor up and clear lines to simulate non-destructive overlay
+        for (int i = 0; i < lines; i++)
+        {
+            Console.SetCursorPosition(0, Math.Max(Console.CursorTop - 1, 0));
+            Console.Write(new string(' ', Console.WindowWidth));
+            Console.SetCursorPosition(0, Math.Max(Console.CursorTop - 1, 0));
+        }
+    }
+
+    private static string Truncate(string s, int width)
+    {
+        if (width <= 0) return string.Empty;
+        if (string.IsNullOrEmpty(s)) return s;
+        if (s.Length <= width) return s;
+        return width <= 1 ? s[..width] : s[..(width - 1)] + "\u2026"; // ellipsis
+    }
+
+    private static void WriteInfo(string message) => Console.WriteLine(message);
+    private static void WriteError(string message)
+    {
+        var c = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine(message);
+        Console.ForegroundColor = c;
+    }
+}

--- a/src/AzStore.Terminal/Selection/IAccountSelectionService.cs
+++ b/src/AzStore.Terminal/Selection/IAccountSelectionService.cs
@@ -1,0 +1,11 @@
+using AzStore.Core.Models.Authentication;
+
+namespace AzStore.Terminal.Selection;
+
+public interface IAccountSelectionService
+{
+    Task<StorageAccountInfo?> PickAsync(
+        IReadOnlyList<StorageAccountInfo> accounts,
+        CancellationToken cancellationToken = default);
+}
+

--- a/src/AzStore.Terminal/Utilities/FuzzyMatchResult.cs
+++ b/src/AzStore.Terminal/Utilities/FuzzyMatchResult.cs
@@ -1,0 +1,4 @@
+namespace AzStore.Terminal.Utilities;
+
+public readonly record struct FuzzyMatchResult<T>(T Item, int Score);
+

--- a/src/AzStore.Terminal/Utilities/IFuzzyMatcher.cs
+++ b/src/AzStore.Terminal/Utilities/IFuzzyMatcher.cs
@@ -1,0 +1,7 @@
+namespace AzStore.Terminal.Utilities;
+
+public interface IFuzzyMatcher
+{
+    IEnumerable<FuzzyMatchResult<T>> MatchAndRank<T>(IEnumerable<T> items, Func<T, IEnumerable<string>> keys, string query);
+}
+

--- a/src/AzStore.Terminal/Utilities/SimpleFuzzyMatcher.cs
+++ b/src/AzStore.Terminal/Utilities/SimpleFuzzyMatcher.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+
+namespace AzStore.Terminal.Utilities;
+
+/// <summary>
+/// Lightweight, allocation-conscious fuzzy matcher using case-insensitive
+/// subsequence/substring scoring. Higher score ranks earlier.
+/// </summary>
+public class SimpleFuzzyMatcher : IFuzzyMatcher
+{
+    public IEnumerable<FuzzyMatchResult<T>> MatchAndRank<T>(IEnumerable<T> items, Func<T, IEnumerable<string>> keys, string query)
+    {
+        query = query?.Trim() ?? string.Empty;
+        if (query.Length == 0)
+        {
+            // No filtering; return neutral score 0
+            foreach (var item in items)
+                yield return new FuzzyMatchResult<T>(item, 0);
+            yield break;
+        }
+
+        var q = query.ToLowerInvariant();
+
+        foreach (var item in items)
+        {
+            var best = int.MinValue;
+            foreach (var key in keys(item))
+            {
+                if (string.IsNullOrEmpty(key))
+                    continue;
+
+                var score = Score(key, q);
+                if (score > best)
+                    best = score;
+            }
+
+            if (best > int.MinValue)
+                yield return new FuzzyMatchResult<T>(item, best);
+        }
+    }
+
+    // Simple scoring:
+    // - Exact case-insensitive substring: base + 100 - startIndex (earlier is better)
+    // - Else subsequence: count of matched chars, contiguous streaks add bonus
+    private static int Score(string text, string query)
+    {
+        var t = text.ToLowerInvariant();
+
+        var idx = t.IndexOf(query, StringComparison.Ordinal);
+        if (idx >= 0)
+        {
+            // Favor earlier match and shorter texts slightly
+            return 1000 + 100 - idx - Math.Min(t.Length, 50);
+        }
+
+        // subsequence match
+        int qi = 0, score = 0, streak = 0;
+        for (int ti = 0; ti < t.Length && qi < query.Length; ti++)
+        {
+            if (t[ti] == query[qi])
+            {
+                qi++;
+                streak++;
+                score += 2;            // base per-char
+                if (streak > 1) score += 1; // contiguous bonus
+            }
+            else
+            {
+                streak = 0;
+            }
+        }
+
+        return qi == query.Length ? score : int.MinValue; // only if fully matched
+    }
+}
+


### PR DESCRIPTION
… preserve console on multi-account (fixes #55)

- Add IAccountSelectionService and console overlay picker
- Add SimpleFuzzyMatcher and config options under AzStore:Selection
- Wire into SessionCommand create flow; no-destructive overlay with VIM-like nav
- Add AccountPickerEngine and unit tests for navigation and session flow
- Update DI registrations and CLAUDE.md docs